### PR TITLE
feat(build/docker): expose build-args to docker build action

### DIFF
--- a/build/docker/action.yml
+++ b/build/docker/action.yml
@@ -1,7 +1,7 @@
 name: Docker to ECR
 description: Push Docker image to ECR
 inputs:
-  push: 
+  push:
     description: "push to registry"
     required: true
     default: "true"
@@ -12,6 +12,9 @@ inputs:
     description: "Docker context for the build"
     required: true
     default: "."
+  build-args:
+    description: "Docker build-time variables for the build (newline delimited, key=value)"
+    required: false
   dockerfile:
     description: "path to Dockerfile"
     required: true
@@ -63,6 +66,7 @@ runs:
         DOCKER_BUILDKIT: "1"
       with:
         context: ${{ inputs.context }}
+        build-args: ${{ inputs.build-args }}
         file: ${{ inputs.dockerfile }}
         push: ${{ inputs.push }}
         cache-from: type=gha


### PR DESCRIPTION
## Context

We needed a way to pass a secret environment variable during the Docker build. So we're adding a `build-args` input that's passed directly to `docker/build-push-action@v2`:

**Dockerfile**
```
ARG SENTRY_AUTH_TOKEN=""
ENV SENTRY_AUTH_TOKEN ${SENTRY_AUTH_TOKEN}
RUN [ ! -z "${SENTRY_AUTH_TOKEN}" ] || { echo "error: SENTRY_AUTH_TOKEN needs to be set"; exit 1; }
```

**.github/workflows/cd.yml**
```
  cd-frontend:
    name: cd-frontend
    runs-on: ubuntu-latest
    timeout-minutes: 15
    steps:
      - uses: actions/checkout@v2
      - uses: botpress/gh-actions/build/docker@av-build-args
        with:
          repository: cdm-front
          context: frontend
          build-args: |
            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
```

## Description

- add `build-args` input (newline delimited list, values in format `key=value`)

