### PR TITLE
fix: added current branch as publish branch

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -34,7 +34,7 @@ jobs:
           done
 
       # If dist/ is different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/publish-if-not-exists/action.yml
+++ b/publish-if-not-exists/action.yml
@@ -42,7 +42,7 @@ runs:
           echo "Unsupported package manager: ${{ inputs.package_manager }}"
           exit 1
         fi
-        
+
         if npm view $package_ref > /dev/null 2>&1 ; then
           echo "Package $package_ref already published"
           exit 0
@@ -51,4 +51,4 @@ runs:
 
         echo "Publishing version $package_ref"
         echo "Using ${{ inputs.package_manager }} as package manager"
-        cd ${{ inputs.path }} && ${{ inputs.package_manager }} publish --access public
+        cd ${{ inputs.path }} && ${{ inputs.package_manager }} publish --access public --publish-branch ${{ github.ref_name }}


### PR DESCRIPTION
Makes sure that we can publish from any branch not only master or main
![image](https://github.com/user-attachments/assets/7743ca14-a005-4af0-a23f-0a9f42ef8827)
