### PR TITLE
chore(action): use new PRIVATE_NPM_TOKEN

### DIFF
--- a/publish-private-package/action.yml
+++ b/publish-private-package/action.yml
@@ -38,7 +38,7 @@ runs:
           echo "exists=false" >> "$GITHUB_OUTPUT"
         fi
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.token }}
+        NODE_AUTH_TOKEN: ${{ secrets.PRIVATE_NPM_TOKEN }}
 
     - name: Publish to GitHub Packages
       if: steps.check.outputs.exists == 'false'
@@ -46,7 +46,7 @@ runs:
       working-directory: ${{ inputs.package-dir }}
       run: pnpm publish --no-git-checks
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.token }}
+        NODE_AUTH_TOKEN: ${{ secrets.PRIVATE_NPM_TOKEN }}
 
     - name: Summary
       shell: bash


### PR DESCRIPTION
- We are now using the @botpress-private registry to host our private packages. This token allows us to publish to that registry