### PR TITLE
fix: include token for deploy

### DIFF
--- a/build/depot/action.yml
+++ b/build/depot/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'Whether to minify the build'
     required: false
     default: true
+  node-auth-token:
+    description: 'GitHub Packages token for resolving @botpress-private/* during the build (optional)'
+    required: false
+    default: ''
 
   # Deploy
   repository:
@@ -129,6 +133,8 @@ runs:
           MINIFY=${{ inputs.minify }}
           DOCKER_TAG=${{ inputs.tag }}
           BUILD_DATE=${{ steps.meta_date.outputs.timestamp }}
+        secrets: |
+          node_auth_token=${{ inputs.node-auth-token }}
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
         push: ${{ inputs.push }}

--- a/build/docker/action.yml
+++ b/build/docker/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'Whether to minify the build'
     required: false
     default: true
+  node-auth-token:
+    description: 'GitHub Packages token for resolving @botpress-private/* during the build (optional)'
+    required: false
+    default: ''
 
   # Publish
   repository:
@@ -126,6 +130,8 @@ runs:
           MINIFY=${{ inputs.minify }}
           DOCKER_TAG=${{ inputs.tag }}
           BUILD_DATE=${{ steps.meta_date.outputs.timestamp }}
+        secrets: |
+          node_auth_token=${{ inputs.node-auth-token }}
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
         push: ${{ inputs.push }}

--- a/full-service-deploy/action.yml
+++ b/full-service-deploy/action.yml
@@ -141,7 +141,7 @@ runs:
     - name: Build and Push Image (Docker)
       if: ${{ inputs.builder == 'docker' }}
       id: build-docker
-      uses: botpress/gh-actions/build/docker@v3.11
+      uses: botpress/gh-actions/build/docker@v3.12
       with:
         dockerfile: ${{ inputs.dockerfile }}
         repository: ${{ inputs.repository }}
@@ -155,7 +155,7 @@ runs:
     - name: Build and Push Image (Depot)
       if: ${{ inputs.builder == 'depot' }}
       id: build-depot
-      uses: botpress/gh-actions/build/depot@v3.11
+      uses: botpress/gh-actions/build/depot@v3.12
       with:
         dockerfile: ${{ inputs.dockerfile }}
         repository: ${{ inputs.repository }}

--- a/full-service-deploy/action.yml
+++ b/full-service-deploy/action.yml
@@ -30,6 +30,10 @@ inputs:
   sentry-auth-token:
     description: 'Sentry auth token (optional)'
     required: false
+  node-auth-token:
+    description: 'GitHub Packages token for resolving @botpress-private/* during the build (optional)'
+    required: false
+    default: ''
   force-build:
     description: 'Whether to force the build if the image already exists'
     type: boolean
@@ -145,6 +149,7 @@ runs:
         tag: ${{ steps.commit.outputs.sha }}
         force: ${{ inputs.force-build }}
         sentry-auth-token: ${{ inputs.sentry-auth-token }}
+        node-auth-token: ${{ inputs.node-auth-token }}
         push: true
 
     - name: Build and Push Image (Depot)
@@ -158,6 +163,7 @@ runs:
         tag: ${{ steps.commit.outputs.sha }}
         force: ${{ inputs.force-build }}
         sentry-auth-token: ${{ inputs.sentry-auth-token }}
+        node-auth-token: ${{ inputs.node-auth-token }}
         depot-project: ${{ inputs.depot-project }}
         push: true
 

--- a/full-service-deploy/action.yml
+++ b/full-service-deploy/action.yml
@@ -141,7 +141,7 @@ runs:
     - name: Build and Push Image (Docker)
       if: ${{ inputs.builder == 'docker' }}
       id: build-docker
-      uses: botpress/gh-actions/build/docker@v3
+      uses: botpress/gh-actions/build/docker@v3.11
       with:
         dockerfile: ${{ inputs.dockerfile }}
         repository: ${{ inputs.repository }}
@@ -155,7 +155,7 @@ runs:
     - name: Build and Push Image (Depot)
       if: ${{ inputs.builder == 'depot' }}
       id: build-depot
-      uses: botpress/gh-actions/build/depot@v3
+      uses: botpress/gh-actions/build/depot@v3.11
       with:
         dockerfile: ${{ inputs.dockerfile }}
         repository: ${{ inputs.repository }}

--- a/full-service-deploy/action.yml
+++ b/full-service-deploy/action.yml
@@ -141,7 +141,7 @@ runs:
     - name: Build and Push Image (Docker)
       if: ${{ inputs.builder == 'docker' }}
       id: build-docker
-      uses: botpress/gh-actions/build/docker@v3.12
+      uses: botpress/gh-actions/build/docker@v3
       with:
         dockerfile: ${{ inputs.dockerfile }}
         repository: ${{ inputs.repository }}
@@ -155,7 +155,7 @@ runs:
     - name: Build and Push Image (Depot)
       if: ${{ inputs.builder == 'depot' }}
       id: build-depot
-      uses: botpress/gh-actions/build/depot@v3.12
+      uses: botpress/gh-actions/build/depot@v3
       with:
         dockerfile: ${{ inputs.dockerfile }}
         repository: ${{ inputs.repository }}


### PR DESCRIPTION
Updates the deployment jobs to support private packages.

Just need to set


 - uses: botpress/gh-actions/full-service-deploy@v3
        with:
...
          node-auth-token: ${{ secrets.PRIVATE_NPM_TOKEN }}